### PR TITLE
feat: Add Calender on MaingPage

### DIFF
--- a/frontend/src/pages/MainPage.jsx
+++ b/frontend/src/pages/MainPage.jsx
@@ -1,25 +1,47 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import Header from "../components/Header";
 import Footer from "../components/Footer";
-import calendarIcon from "../assets/calendar_icon.png";
+import {
+  getFirstDayOfMonth,
+  getLastDayOfMonth,
+  getDayOfWeek,
+  formatDateToYYYYMMDD,
+  isToday,
+  areDatesEqual,
+  isBeforeToday,
+  areMonthsEqual
+} from "../utils/dateUtils";
 import "../styles/MainPage.css";
 
 const MainPage = () => {
-  const [selectedDate, setSelectedDate] = useState("");
   const navigate = useNavigate();
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const [currentMonth, setCurrentMonth] = useState(new Date());
+  const [selectedDate, setSelectedDate] = useState(null);
 
-  const handleDateChange = (e) => {
-    const selectedDate = e.target.value;  // YYYY-MM-DD 형식
-    setSelectedDate(selectedDate);
+  useEffect(() => {
+    setCurrentMonth(new Date(today.getFullYear(), today.getMonth(), 1));
+  }, []);
+
+  const handleDayClick = (date) => {
+    if (isBeforeToday(date)) {
+      return;
+    }
+    setSelectedDate(date);
   };
 
-  const handleViewTable = () => {
+  const handleConfirm = () => {
     if (selectedDate) {
+      if (isBeforeToday(selectedDate)) {
+        alert('오늘 이전의 날짜는 예약할 수 없습니다.');
+        return;
+      }
       navigate('/table-view', {
         state: {
-          selectedDate: selectedDate,  // YYYY-MM-DD 형식 그대로 사용
-          originalDate: selectedDate
+          selectedDate: formatDateToYYYYMMDD(selectedDate),
+          originalDate: formatDateToYYYYMMDD(selectedDate)
         }
       });
     } else {
@@ -27,39 +49,134 @@ const MainPage = () => {
     }
   };
 
+  const goToPrevMonth = () => {
+    const prevMonthDate = new Date(currentMonth);
+    prevMonthDate.setMonth(currentMonth.getMonth() - 1);
+    const firstDayOfCurrentMonth = new Date(today.getFullYear(), today.getMonth(), 1);
+    if (prevMonthDate.getTime() < firstDayOfCurrentMonth.getTime()) {
+      return;
+    }
+    setCurrentMonth(prevMonthDate);
+  };
+
+  const goToNextMonth = () => {
+    const nextMonthDate = new Date(currentMonth);
+    nextMonthDate.setMonth(currentMonth.getMonth() + 1);
+    const maxMonth = new Date(today.getFullYear(), today.getMonth() + 2, 1);
+    if (nextMonthDate.getTime() > maxMonth.getTime()) {
+      return;
+    }
+    setCurrentMonth(nextMonthDate);
+  };
+
+  const goToToday = () => {
+    setCurrentMonth(new Date(today.getFullYear(), today.getMonth(), 1));
+    setSelectedDate(null);
+  };
+
+  const isPrevMonthDisabled = areMonthsEqual(currentMonth, today);
+  const maxAllowedMonth = new Date(today.getFullYear(), today.getMonth() + 2, 1);
+  const isNextMonthDisabled = areMonthsEqual(currentMonth, maxAllowedMonth);
+
+  const renderCalendarDays = () => {
+    const year = currentMonth.getFullYear();
+    const month = currentMonth.getMonth();
+
+    const firstDayOfMonth = getFirstDayOfMonth(year, month);
+    const lastDayOfMonth = getLastDayOfMonth(year, month);
+    const numDaysInMonth = lastDayOfMonth.getDate();
+    const startingDayOfWeek = getDayOfWeek(firstDayOfMonth);
+    const numDaysLastMonth = new Date(year, month, 0).getDate();
+    const numDaysNextMonth = new Date(year, month + 1, 1).getDate(); // 다음 달의 총 일수 (실제로는 1일의 getDate)
+
+    const days = [];
+
+    // 이전 달의 날짜 (이번 달 첫째 날 이전 공백 채우기)
+    for (let i = startingDayOfWeek; i > 0; i--) {
+      const day = numDaysLastMonth - i + 1;
+      const date = new Date(year, month - 1, day);
+      days.push(
+        <div key={`prev-${day}`} className="calendar-day other-month">
+          {day}
+        </div>
+      );
+    }
+
+    // 현재 달의 날짜
+    for (let day = 1; day <= numDaysInMonth; day++) {
+      const currentDate = new Date(year, month, day);
+      currentDate.setHours(0,0,0,0);
+      const isSelected = areDatesEqual(currentDate, selectedDate);
+      const isDayToday = isToday(currentDate);
+      const isDisabled = isBeforeToday(currentDate);
+
+      let dayClasses = "calendar-day";
+      if (isDayToday) dayClasses += " today";
+      if (isSelected) dayClasses += " selected";
+      if (isDisabled) dayClasses += " disabled";
+
+      days.push(
+        <div
+          key={`current-${day}`}
+          className={dayClasses}
+          onClick={isDisabled ? null : () => handleDayClick(currentDate)}
+        >
+          {day}
+        </div>
+      );
+    }
+
+    // 다음 달의 날짜 (이번 달 마지막 날 이후 공백 채우기)
+    const remainingDays = 42 - days.length;
+    for (let i = 1; i <= remainingDays; i++) {
+      const day = i;
+      const date = new Date(year, month + 1, day);
+      days.push(
+        <div key={`next-${day}`} className="calendar-day other-month">
+          {day}
+        </div>
+      );
+    }
+
+    return days;
+  };
+
   return (
     <div className="main-page">
       <Header />
       <div className="main-container">
-        <h1>Reservation</h1>
-        <div className="reservation-box">
-          <div className="date-input-container">
-            <input
-              type="text"
-              placeholder="날짜를 선택해주세요"
-              className="date-input"
-              value={selectedDate}
-              readOnly
-            />
-            <label className="calendar-label">
-              <input
-                type="date"
-                onChange={handleDateChange}
-                className="calendar-input"
-              />
-              <img 
-                src={calendarIcon} 
-                alt="달력" 
-                className="calendar-icon"
-              />
-            </label>
+        <h2>예약 날짜를 선택해주세요</h2>
+        <div className="calendar-box">
+          <div className="calendar-header">
+            <span className="today-button" onClick={goToToday}>
+              오늘
+            </span>
+            <div className="month-navigator">
+              <button onClick={goToPrevMonth} disabled={isPrevMonthDisabled}>&lt;</button>
+              <span>
+                {currentMonth.getFullYear()}년 {currentMonth.getMonth() + 1}월
+              </span>
+              <button onClick={goToNextMonth} disabled={isNextMonthDisabled}>&gt;</button>
+            </div>
           </div>
-          <button 
-            className={`reserve-button ${selectedDate ? 'active' : ''}`}
+          <div className="calendar-grid">
+            <div className="calendar-weekdays">
+              <span>일</span>
+              <span>월</span>
+              <span>화</span>
+              <span>수</span>
+              <span>목</span>
+              <span>금</span>
+              <span>토</span>
+            </div>
+            <div className="calendar-days">{renderCalendarDays()}</div>
+          </div>
+          <button
+            className="confirm-button"
+            onClick={handleConfirm}
             disabled={!selectedDate}
-            onClick={handleViewTable}
           >
-            View Table
+            확인
           </button>
         </div>
       </div>
@@ -68,4 +185,4 @@ const MainPage = () => {
   );
 };
 
-export default MainPage; 
+export default MainPage;

--- a/frontend/src/styles/MainPage.css
+++ b/frontend/src/styles/MainPage.css
@@ -1,103 +1,187 @@
 .main-page {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  min-width: 800px;
-  padding-top: 70px;
-  font-family: 'Noto Sans KR', sans-serif;
-  background-color: #ffffff;
   display: flex;
   flex-direction: column;
+  min-height: 100vh;
+  background-color: #ffffff;
+  font-family: 'Noto Sans KR', sans-serif;
 }
 
 .main-container {
-  flex: 1;
+  flex-grow: 1;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   padding: 20px;
+  width: 100%;
+  box-sizing: border-box;
 }
 
-h1 {
-  font-size: 36px;
-  font-weight: normal;
-  margin-bottom: 40px;
+.main-container h2 {
+  color: #333;
+  margin-bottom: 30px;
+  font-size: 28px;
+  font-weight: 600;
+}
+
+.calendar-box {
+  background-color: #fff;
+  border-radius: 8px;
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.05); /* 은은한 그림자 */
+  padding: 30px;
+  width: 100%;
+  max-width: 500px; /* 캘린더 최대 너비 */
+  box-sizing: border-box;
+}
+
+.calendar-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 25px;
+  font-size: 18px;
+  font-weight: 600;
   color: #333;
 }
 
-.reservation-box {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 20px;
-}
-
-.date-input-container {
-  position: relative;
-  width: 350px;
-}
-
-.date-input {
-  width: 100%;
-  padding: 12px 0px 12px 15px;
-  font-size: 23px;
-  border: 1px solid #ddd;
-  border-radius: 13px;
-  background-color: #fff;
+.calendar-header .today-button {
+  color: #2962ff;
   cursor: pointer;
-}
-
-.date-input:focus {
-  outline: none;
-  border-color: #2962ff;
-}
-
-.calendar-label {
-  position: absolute;
-  right: 0px;
-  top: 50%;
-  transform: translateY(-50%);
-  cursor: pointer;
-}
-
-.calendar-input {
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  opacity: 0;
-  cursor: pointer;
-}
-
-.calendar-icon {
-  width: 20px;
-  height: 20px;
-  object-fit: contain;
-}
-
-.reserve-button {
-  width: 300px;
-  padding: 12px;
   font-size: 16px;
-  background-color: #bfbdbd;
-  color: white;
+  font-weight: 500;
+  padding: 5px 10px;
+  border-radius: 5px;
+  transition: background-color 0.2s ease;
+}
+
+.calendar-header .today-button:hover {
+  background-color: #2962ff; /* 호버 시 배경색 (기존 대표색 유지) */
+  color: #ffffff; /* 호버 시 글자색 흰색으로 변경 */
+}
+
+.month-navigator {
+  display: flex;
+  align-items: center;
+}
+
+.month-navigator button {
+  background: none;
   border: none;
-  border-radius: 4px;
-  cursor: not-allowed;
-  transition: background-color 0.2s;
-}
-
-.reserve-button.active {
-  background-color: #2962ff;
+  font-size: 24px;
+  color: #333;
   cursor: pointer;
+  padding: 0 10px;
+  transition: color 0.2s ease;
 }
 
-.reserve-button.active:hover {
+.month-navigator button:hover {
+  color: #2962ff; /* 대표색 */
+}
+
+.month-navigator span {
+  margin: 0 15px;
+  white-space: nowrap; /* 월/연도 텍스트가 줄바꿈되지 않도록 */
+}
+
+.calendar-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 5px;
+  text-align: center;
+}
+
+.calendar-weekdays {
+  display: contents; /* 자식 요소들이 그리드 아이템이 되도록 */
+}
+
+.calendar-weekdays span {
+  font-weight: 500;
+  color: #888;
+  padding: 10px 0;
+  border-bottom: 1px solid #eee;
+  font-size: 14px;
+}
+
+.calendar-days {
+  display: contents; /* 자식 요소들이 그리드 아이템이 되도록 */
+}
+
+.calendar-day {
+  width: 40px;
+  height: 40px;
+  line-height: 40px;
+  border-radius: 50%;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease;
+  font-size: 16px;
+  color: #333;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.calendar-day:hover:not(.selected):not(.other-month):not(.disabled) {
+  background-color: #f0f0f0;
+}
+
+.calendar-day.other-month {
+  color: #ccc; /* 이전/다음 달 날짜 색상 */
+  cursor: default;
+}
+
+.calendar-day.other-month:hover {
+  background-color: transparent;
+}
+
+.calendar-day.today {
+  color: #2962ff;
+  font-weight: 600;
+}
+
+.calendar-day.selected {
+  background-color: #2962ff;
+  color: #ffffff;
+  font-weight: 600;
+}
+
+.confirm-button {
+  width: 100%;
+  padding: 15px;
+  margin-top: 30px;
+  background-color: #2962ff;
+  color: #ffffff;
+  border: none;
+  border-radius: 8px; /* 둥근 모서리 */
+  font-size: 18px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.3s ease;
+}
+
+.confirm-button:hover:not(:disabled) {
   background-color: #1541bb;
 }
 
-.reserve-button:focus {
-  outline: none;
-} 
+.confirm-button:disabled {
+  background-color: #a7c3ff; /* 비활성화 시 색상 */
+  cursor: default;
+}
+
+/* 선택할 수 없는 비활성화된 요소 */
+.calendar-day.disabled {
+  color: #c0c0c0; /* 회색 텍스트 */
+  cursor: default;
+}
+
+.calendar-day.disabled:hover {
+  background-color: transparent; /* 호버 시 배경색 제거 */
+}
+
+/* 빈 셀 (그리드 정렬용) */
+.calendar-day.empty-cell {
+  background-color: transparent;
+  cursor: default;
+}
+.calendar-day.empty-cell:hover {
+  background-color: transparent;
+}

--- a/frontend/src/utils/dateUtils.js
+++ b/frontend/src/utils/dateUtils.js
@@ -1,0 +1,106 @@
+/**
+ * 주어진 연월의 첫째 날짜를 반환합
+ * @param {number} year
+ * @param {number} month (0-11)
+ * @returns {Date}
+ */
+export const getFirstDayOfMonth = (year, month) => {
+  return new Date(year, month, 1);
+};
+
+/**
+ * 주어진 연월의 마지막 날짜를 반환
+ * @param {number} year
+ * @param {number} month (0-11)
+ * @returns {Date}
+ */
+export const getLastDayOfMonth = (year, month) => {
+  return new Date(year, month + 1, 0);
+};
+
+/**
+ * 주어진 날짜의 요일 인덱스를 반환 (일요일: 0, 월요일: 1, ...)
+ * @param {Date} date
+ * @returns {number}
+ */
+export const getDayOfWeek = (date) => {
+  return date.getDay();
+};
+
+/**
+ * Date 객체를 YYYY-MM-DD 형식의 문자열로 변환
+ * @param {Date} date
+ * @returns {string}
+ */
+export const formatDateToYYYYMMDD = (date) => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+/**
+ * YYYY-MM-DD 형식의 문자열을 Date 객체로 변환
+ * @param {string} dateString
+ * @returns {Date}
+ */
+export const parseYYYYMMDDToDate = (dateString) => {
+  const [year, month, day] = dateString.split('-').map(Number);
+  return new Date(year, month - 1, day);
+};
+
+/**
+ * 현재 날짜가 오늘인지 확인
+ * @param {Date} date
+ * @returns {boolean}
+ */
+export const isToday = (date) => {
+  const today = new Date();
+  return (
+    date.getFullYear() === today.getFullYear() &&
+    date.getMonth() === today.getMonth() &&
+    date.getDate() === today.getDate()
+  );
+};
+
+/**
+ * 두 날짜가 같은 날짜인지 확인 (연, 월, 일만 비교)
+ * @param {Date} date1
+ * @param {Date} date2
+ * @returns {boolean}
+ */
+export const areDatesEqual = (date1, date2) => {
+    if (!date1 || !date2) return false;
+    return (
+        date1.getFullYear() === date2.getFullYear() &&
+        date1.getMonth() === date2.getMonth() &&
+        date1.getDate() === date2.getDate()
+    );
+};
+
+/**
+ * 주어진 날짜가 오늘 이전인지 확인 (오늘 포함 안 함)
+ * @param {Date} date
+ * @returns {boolean}
+ */
+export const isBeforeToday = (date) => {
+  const today = new Date();
+  // 시간 정보는 무시하고 날짜만 비교하기 위해 자정으로 설정
+  today.setHours(0, 0, 0, 0);
+  date.setHours(0, 0, 0, 0);
+  return date.getTime() < today.getTime();
+};
+
+/**
+ * 두 달이 같은 달인지 확인 (연, 월만 비교)
+ * @param {Date} date1
+ * @param {Date} date2
+ * @returns {boolean}
+ */
+export const areMonthsEqual = (date1, date2) => {
+  if (!date1 || !date2) return false;
+  return (
+    date1.getFullYear() === date2.getFullYear() &&
+    date1.getMonth() === date2.getMonth()
+  );
+};


### PR DESCRIPTION
- 로그인 후 메인 페이지에서 날짜를 선택할 수 있는 캘린더를 추가했습니다.
- 캘린더 표시 기준은 다음과 같습니다.
1. 접속 시 클라이언트의 날짜와 월을 게산해 오늘을 파란색으로 표시
2. 오늘 이전과 현재 선택한 달의 다음 달 날짜는 선택할 수 없음
3. 이번 달에서부터 두 달 이후까지만 조회할 수 있음